### PR TITLE
Remove old Launcher File due to File Rename

### DIFF
--- a/GameLauncherUpdater/Properties/AssemblyInfo.cs
+++ b/GameLauncherUpdater/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("c3dfd242-2688-4228-88e8-d4588cba1833")]
 
-[assembly: AssemblyVersion("1.0.1.04")]
-[assembly: AssemblyFileVersion("1.0.1.04")]
+[assembly: AssemblyVersion("1.0.1.06")]
+[assembly: AssemblyFileVersion("1.0.1.06")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/GameLauncherUpdater/Updater.cs
+++ b/GameLauncherUpdater/Updater.cs
@@ -211,6 +211,18 @@ namespace GameLauncherUpdater
                                 if (File.Exists("SBRW.Launcher.exe"))
                                 {
                                     Process.Start(@"SBRW.Launcher.exe");
+
+                                    try
+                                    {
+                                        if (File.Exists("GameLauncher.exe"))
+                                        {
+                                            File.Delete("GameLauncher.exe");
+                                        }
+                                    }
+                                    catch
+                                    {
+
+                                    }
                                 }
                                 else if (File.Exists("GameLauncher.exe"))
                                 {
@@ -319,6 +331,18 @@ namespace GameLauncherUpdater
             if (File.Exists("SBRW.Launcher.exe"))
             {
                 Process.Start(@"SBRW.Launcher.exe");
+
+                try
+                {
+                    if (File.Exists("GameLauncher.exe"))
+                    {
+                        File.Delete("GameLauncher.exe");
+                    }
+                }
+                catch
+                {
+
+                }
             }
             else if (File.Exists("GameLauncher.exe"))
             {


### PR DESCRIPTION
Checks:
- Remove old Launcher File 'GameLauncher.exe'
-- If 'SBRW.Launcher.exe' is present