### PR TITLE
Fix Insider Build Version Comparisons

### DIFF
--- a/GameLauncherUpdater/App/Classes/UpdaterCore/Support/Strings.cs
+++ b/GameLauncherUpdater/App/Classes/UpdaterCore/Support/Strings.cs
@@ -3,9 +3,9 @@ using System.Text;
 
 namespace GameLauncherUpdater.App.Classes.UpdaterCore.Support
 {
-    class Strings
+    public static class Strings
     {
-        public static string Encode(string Value)
+        public static string Encode(this string Value)
         {
             return Encoding.UTF8.GetString(Encoding.UTF8.GetBytes(Value));
         }
@@ -25,7 +25,7 @@ namespace GameLauncherUpdater.App.Classes.UpdaterCore.Support
         /// <b>1</b> if v1 is higher version number than v2<br></br>
         /// <b>-1000</b> if we couldn't figure it out (something went wrong)
         /// </returns>
-        public static int Comparisons(string v1, string v2)
+        public static int Comparisons(this string v1, string v2)
         {
             if (string.IsNullOrWhiteSpace(v1) || string.IsNullOrWhiteSpace(v2))
             {

--- a/GameLauncherUpdater/Properties/AssemblyInfo.cs
+++ b/GameLauncherUpdater/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("c3dfd242-2688-4228-88e8-d4588cba1833")]
 
-[assembly: AssemblyVersion("1.0.1.18")]
-[assembly: AssemblyFileVersion("1.0.1.18")]
+[assembly: AssemblyVersion("1.0.1.20")]
+[assembly: AssemblyFileVersion("1.0.1.20")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/GameLauncherUpdater/Updater.cs
+++ b/GameLauncherUpdater/Updater.cs
@@ -85,7 +85,7 @@ namespace GameLauncherUpdater
                                 Temp_Latest_Launcher_Build = GH_Releases;
                             }
 
-                            if (Current_Launcher_Build.CompareTo(GH_Releases.tag_name) < 0)
+                            if (Current_Launcher_Build.Comparisons(GH_Releases.tag_name) < 0)
                             {
                                 return GH_Releases;
                             }
@@ -254,7 +254,7 @@ namespace GameLauncherUpdater
                             Insider_Release_Tag(JSONFile, Version) :
                             new JavaScriptSerializer().Deserialize<GitHubReleaseSchema>(JSONFile);
                             int Revision = UsingDevelopment ? 
-                            Version_Build.CompareTo(LatestLauncherBuild.tag_name) : Strings.Comparisons(Version, LatestLauncherBuild.tag_name);
+                            Version_Build.CompareTo(LatestLauncherBuild.tag_name) : Version.Comparisons(LatestLauncherBuild.tag_name);
                             if (Revision < 0)
                             {
                                 WebClient client2 = new WebClient();


### PR DESCRIPTION
Fixed:
- If a user has opted into Insider Builds, they should now be able to update to latest stable (rather than being stuck on an older release)