### PR TITLE
Fix Null Exception for Version Comparison

### DIFF
--- a/GameLauncherUpdater/Properties/AssemblyInfo.cs
+++ b/GameLauncherUpdater/Properties/AssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("c3dfd242-2688-4228-88e8-d4588cba1833")]
 
-[assembly: AssemblyVersion("1.0.1.22")]
-[assembly: AssemblyFileVersion("1.0.1.22")]
+[assembly: AssemblyVersion("1.0.1.24")]
+[assembly: AssemblyFileVersion("1.0.1.24")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/GameLauncherUpdater/Updater.cs
+++ b/GameLauncherUpdater/Updater.cs
@@ -253,7 +253,7 @@ namespace GameLauncherUpdater
                             GitHubReleaseSchema LatestLauncherBuild = (UsingPreview) ?
                             Insider_Release_Tag(JSONFile, Version) :
                             new JavaScriptSerializer().Deserialize<GitHubReleaseSchema>(JSONFile);
-                            if (Version_Build.Replace('-', '.').Outdated(LatestLauncherBuild.tag_name.Replace('-', '.')))
+                            if ((Version_Build??Version).Replace('-', '.').Outdated(LatestLauncherBuild.tag_name.Replace('-', '.')))
                             {
                                 WebClient client2 = new WebClient();
                                 client2.Headers.Add("user-agent", "GameLauncherUpdater " + Application.ProductVersion +


### PR DESCRIPTION
Fixed:
- Version comparison throwing an exception due to version builds not comparing correctly -- Version was always null and not fail safe(ing) to the launcher version